### PR TITLE
delete関数の引数を修正し、日付を考慮したタスク削除機能を実装

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,10 @@ def add():
 def delete(date, todo_id):
     if date in todos and 0 <= todo_id < len(todos[date]):
         todos[date].pop(todo_id)
-    return redirect(url_for('index', start_date=date))
+        return redirect(url_for('index', start_date=date))
+    else:
+        app.logger.warning(f"Failed to delete todo: date={date}, todo_id={todo_id} - Invalid date or todo_id.")
+        return jsonify({'error': 'Invalid date or todo_id'}), 400
 
 @app.route('/update_status/<date>/<int:todo_id>', methods=['POST'])
 def update_status(date, todo_id):

--- a/app.py
+++ b/app.py
@@ -27,11 +27,11 @@ def add():
         todos[date].append({'summary': summary, 'details': details, 'status': '未'})
     return redirect(url_for('index', start_date=date))
 
-@app.route('/delete/<int:todo_id>')
-def delete(todo_id):
-    if 0 <= todo_id < len(todos):
-        todos.pop(todo_id)
-    return redirect(url_for('index'))
+@app.route('/delete/<date>/<int:todo_id>')
+def delete(date, todo_id):
+    if date in todos and 0 <= todo_id < len(todos[date]):
+        todos[date].pop(todo_id)
+    return redirect(url_for('index', start_date=date))
 
 @app.route('/update_status/<date>/<int:todo_id>', methods=['POST'])
 def update_status(date, todo_id):


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
This pull request updates the `delete` route in `app.py` to support deleting todos by both date and ID, ensuring that todos are correctly managed within their respective dates.

Routing and functionality improvements:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L30-R34): Modified the `delete` route to accept a `date` parameter in addition to the `todo_id`. This ensures that todos are deleted from the correct date-specific list. The route now checks if the specified date exists in `todos` and validates the `todo_id` within that date's list before deletion.